### PR TITLE
a much better way to import packs from JSON

### DIFF
--- a/src/module/InvestigatorCompendiumDirectory.ts
+++ b/src/module/InvestigatorCompendiumDirectory.ts
@@ -5,7 +5,7 @@ import CompendiumDirectory = foundry.applications.sidebar.tabs.CompendiumDirecto
 import { nanoid } from "nanoid";
 
 import { saveAsJsonFile } from "../functions/saveFile";
-import { getUserFile, systemLogger } from "../functions/utilities";
+import { getUserFile } from "../functions/utilities";
 import { RecursivePartial } from "../types";
 
 const importButtonIconClass = "fa-cloud-arrow-up";
@@ -220,28 +220,19 @@ export class InvestigatorCompendiumDirectory<
     ui.notifications?.info(
       `Beginning import of compendium pack ${verified.label}`,
     );
-    const pack = await CompendiumCollection.createCompendium({
-      type: verified.entity,
-      label: verified.label,
-      name,
-    });
     const maker = {
       Actor,
       Item,
       JournalEntry,
     }[verified.entity];
-
-    // @ts-expect-error we're doing some insane jiggerypokery and i cba to work
-    // out hiw to fix the fypes
-    const entities = await maker.create(verified.contents as any, {
-      temporary: true,
+    const pack = await CompendiumCollection.createCompendium({
+      type: verified.entity,
+      label: verified.label,
+      name,
     });
-    for (const entity of entities as any) {
-      await pack.importDocument(entity);
-      systemLogger.log(
-        `Imported ${verified.entity} ${entity.name} into Compendium pack ${pack.collection}`,
-      );
-    }
+    await maker.createDocuments(verified.contents, {
+      pack: pack.metadata.id,
+    });
 
     pack.apps.forEach((app) =>
       app instanceof foundry.appv1.api.Application

--- a/src/module/InvestigatorCompendiumDirectory.ts
+++ b/src/module/InvestigatorCompendiumDirectory.ts
@@ -235,7 +235,9 @@ export class InvestigatorCompendiumDirectory<
         pack: pack.metadata.id,
       });
     } catch (e) {
-      await pack.deleteCompendium();
+      try {
+        await pack.deleteCompendium();
+      } catch {}
       throw e;
     }
 

--- a/src/module/InvestigatorCompendiumDirectory.ts
+++ b/src/module/InvestigatorCompendiumDirectory.ts
@@ -206,13 +206,13 @@ export class InvestigatorCompendiumDirectory<
     if (candidate.label === undefined) {
       throw new Error("Candidate compendium did not contain a label");
     }
-    if (candidate.entity === undefined) {
+    if (!(
+      candidate.entity &&
+      ["Actor", "Item", "JournalEntry"].includes(candidate.entity)
+    )) {
       throw new Error("Candidate compendium did not contain an entity");
     }
-    if (
-      candidate.contents === undefined ||
-      candidate.contents.length === undefined
-    ) {
+    if (!Array.isArray(candidate.contents)) {
       throw new Error("Candidate compendium did not contain any contents");
     }
     const verified = candidate as ExportedCompendium;
@@ -230,9 +230,14 @@ export class InvestigatorCompendiumDirectory<
       label: verified.label,
       name,
     });
-    await maker.createDocuments(verified.contents, {
-      pack: pack.metadata.id,
-    });
+    try {
+      await maker.createDocuments(verified.contents, {
+        pack: pack.metadata.id,
+      });
+    } catch (e) {
+      await pack.deleteCompendium();
+      throw e;
+    }
 
     pack.apps.forEach((app) =>
       app instanceof foundry.appv1.api.Application


### PR DESCRIPTION
Our hand-rolled system for exporting and importing  compendium packs had a weird wrinkle: when importing, spare copies of all the documents were left lying around in the world. This PR fixes how we do that import so it's less daft and doesn't leave copies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compendium imports by creating documents directly in the destination pack.
  * Streamlined imports to reduce unnecessary intermediate processing and improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->