### PR TITLE
Fix #1380 (Push chat card errors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 (Skipped version numbers are testing releases.)
 
+## Unreleased
+
+- BUGFIX: Push pool chat cards were recording the ability's own id as the actor id, so the card could not find the character it belonged to and rendered as a blank space in the chat log (#1380, thanks @Xyxorswords). This mostly bit you if the ability was pushed from a sidebar actor or a linked token; pushing from an unlinked token happened to work, which is why it went unnoticed for so long. Cards posted before this fix can't be repaired, because the bad id is baked into the message content - but see below.
+- Ability cards that can't be resolved - because the character or the item has since been deleted, or because they were posted by an older version of the system - now render a static "this card can no longer be displayed" placeholder explaining what went wrong, instead of an empty gap. One of these cases used to throw an uncaught error.
+
 ## 10.121 (2026-08-19)
 
 Fixes #148, #835, and #1320.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ## Unreleased
 
-- BUGFIX: Push pool chat cards were recording the ability's own id as the actor id, so the card could not find the character it belonged to and rendered as a blank space in the chat log (#1380, thanks @Xyxorswords). This mostly bit you if the ability was pushed from a sidebar actor or a linked token; pushing from an unlinked token happened to work, which is why it went unnoticed for so long. Cards posted before this fix can't be repaired, because the bad id is baked into the message content - but see below.
-- Ability cards that can't be resolved - because the character or the item has since been deleted, or because they were posted by an older version of the system - now render a static "this card can no longer be displayed" placeholder explaining what went wrong, instead of an empty gap. One of these cases used to throw an uncaught error.
+- BUGFIX: Push pool chat cards were recording the ability's own id as the actor id, so the card could not find the character it belonged to and rendered as a blank space in the chat log (#1380, thanks @Xyxorswords). This mostly happened if the ability was pushed from a sidebar actor or a linked token; pushing from an unlinked token happened to work, which is why it went unnoticed for so long. Cards posted before this fix can't be repaired, because the bad id is baked into the message content, but see below.
+- Ability cards that can't be resolved: because the character or the item has since been deleted, or because they were posted by an older version of the system - now render a static "this card can no longer be displayed" placeholder explaining what went wrong, instead of an empty gap.
+- Ability cards are also better at finding their actor in the first place: they now try the token and the world actor in turn, rather than committing to one and giving up. This fixes some long-standing cases where a card would go blank just because its token was on a scene you weren't looking at.
 
 ## 10.121 (2026-08-19)
 

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -27,6 +27,10 @@
   "investigator.BaseDamage": "Base damage",
   "investigator.BonusPool": "Bonus pool",
   "investigator.Boost": "Boost?",
+  "investigator.BrokenCardInvalidMode": "This card was written with an unrecognised roll type and can no longer be displayed.",
+  "investigator.BrokenCardMissingActor": "The character this card refers to can no longer be found.",
+  "investigator.BrokenCardMissingActorId": "This card does not record which character it belongs to and can no longer be displayed.",
+  "investigator.BrokenCardMissingItem": "The item this card refers to can no longer be found.",
   "investigator.CanAbilitiesBeBoosted": "Can abilities be boosted",
   "investigator.CanBeInvestigative": "Can be investigative?",
   "investigator.Cancel": "Cancel",
@@ -270,5 +274,6 @@
   "investigator.ImportFromFile": "Import from JSON",
   "investigator.CreateClassicCombat": "Create classic combat",
   "investigator.CreateTurnPassingCombat": "Create turn-passing combat",
-  "investigator.SortCombatants": "Sort Combatants"
+  "investigator.SortCombatants": "Sort Combatants",
+  "investigator.UnknownAbility": "Unknown ability"
 }

--- a/src/components/messageCards/BrokenCard.tsx
+++ b/src/components/messageCards/BrokenCard.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+
+import { useTheme } from "../../hooks/useTheme";
+import { Translate } from "../Translate";
+
+interface BrokenCardProps {
+  name: string | null;
+  imageUrl: string | null;
+  /** translation key explaining why the card could not be rendered */
+  reason: string;
+}
+
+/**
+ * Static stand-in for an ability card whose actor or item can't be resolved.
+ * Chat message content is immutable, so a card written by an older version of
+ * the system (or one whose actor or item has since been deleted) can never be
+ * made interactive again - the best we can do is show what we know and say why.
+ */
+export const BrokenCard = React.memo(
+  ({ name, imageUrl, reason }: BrokenCardProps) => {
+    const theme = useTheme();
+
+    return (
+      <div
+        className="dice-roll"
+        css={{
+          position: "relative",
+          display: "grid",
+          gridTemplateColumns: "max-content 1fr",
+          gridTemplateAreas: '"image headline"',
+          alignItems: "center",
+          justifyItems: "start",
+          opacity: 0.7,
+        }}
+      >
+        {imageUrl && (
+          <div
+            css={{
+              height: "4em",
+              width: "4em",
+              gridArea: "image",
+              backgroundImage: `url(${imageUrl})`,
+              backgroundSize: "cover",
+              backgroundRepeat: "no-repeat",
+              backgroundPosition: "center",
+              marginRight: "1em",
+              filter: "grayscale(1)",
+            }}
+          />
+        )}
+        <div css={{ gridArea: "headline" }}>
+          <div
+            css={{
+              fontSize: "1.5em",
+              fontStyle: "italic",
+              color: theme.colors.accent,
+            }}
+          >
+            {name ?? <Translate>UnknownAbility</Translate>}
+          </div>
+          <div css={{ fontSize: "0.9em" }}>
+            <Translate>{reason}</Translate>
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+
+BrokenCard.displayName = "BrokenCard";

--- a/src/module/items/generalAbility.ts
+++ b/src/module/items/generalAbility.ts
@@ -62,11 +62,11 @@ export class GeneralAbilityModel extends AbilityModel<
         <div
           class="${constants.abilityChatMessageClassName}"
           ${constants.htmlDataItemId}="${from?.id ?? this.parent.id}"
-          ${constants.htmlDataActorId}="${this.parent?.id ?? ""}"
+          ${constants.htmlDataActorId}="${this.parent.parent?.id ?? ""}"
           ${constants.htmlDataMode}="${constants.htmlDataModePush}"
           ${constants.htmlDataName}="${from?.name ?? this.parent.name}"
           ${constants.htmlDataImageUrl}="${this.parent.img}"
-          ${constants.htmlDataTokenId}="${this.parent?.actor.token?.id ?? ""}"
+          ${constants.htmlDataTokenId}="${this.parent.parent?.token?.id ?? ""}"
         />
       `,
     });

--- a/src/startup/installAbilityCardChatWrangler.tsx
+++ b/src/startup/installAbilityCardChatWrangler.tsx
@@ -5,12 +5,13 @@ import { AbilityNegateOrWallopMwCard } from "../components/messageCards/AbilityN
 import { AbilityTestCard } from "../components/messageCards/AbilityTestCard";
 import { AbilityTestMwCard } from "../components/messageCards/AbilityTestMwCard";
 import { AttackCard } from "../components/messageCards/AttackCard";
+import { BrokenCard } from "../components/messageCards/BrokenCard";
 import { PushCard } from "../components/messageCards/PushCard";
 import { isAbilityCardMode } from "../components/messageCards/types";
 import * as constants from "../constants";
 import { assertGame } from "../functions/isGame";
 import { systemLogger } from "../functions/utilities";
-import { assertAbilityItem } from "../module/items/exports";
+import { isAbilityItem } from "../module/items/exports";
 import { MWDifficulty } from "../types";
 
 export const installAbilityCardChatWrangler = () => {
@@ -37,11 +38,20 @@ export const installAbilityCardChatWrangler = () => {
       const name = el.getAttribute(constants.htmlDataName);
       const imageUrl = el.getAttribute(constants.htmlDataImageUrl);
 
+      // chat message content is immutable, so anything we can't resolve here is
+      // unfixable - render a static stand-in rather than leaving an empty div
+      const renderBroken = (reason: string) => {
+        createRoot(el).render(
+          <BrokenCard name={name} imageUrl={imageUrl} reason={reason} />,
+        );
+      };
+
       if (actorId === null) {
         systemLogger.error(
           `Missing or invalid '${constants.htmlDataActorId}' attribute.`,
           el,
         );
+        renderBroken("BrokenCardMissingActorId");
         return;
       }
       if (mode === null || !isAbilityCardMode(mode)) {
@@ -51,6 +61,7 @@ export const installAbilityCardChatWrangler = () => {
             '(Valid values are "test", "spend", "combat", "push"',
           el,
         );
+        renderBroken("BrokenCardInvalidMode");
         return;
       }
 
@@ -62,15 +73,20 @@ export const installAbilityCardChatWrangler = () => {
 
       if (actor === undefined || actor === null) {
         systemLogger.error(`Could not find actor with id ${actorId}`, el);
+        renderBroken("BrokenCardMissingActor");
         return;
       }
 
       const ability = abilityId ? actor.items.get(abilityId) : undefined;
-      assertAbilityItem(ability);
 
       let content: ReactNode;
       if (mode === constants.htmlDataModeAttack) {
         const weapon = weaponId ? actor.items.get(weaponId) : undefined;
+        if (weapon === undefined) {
+          systemLogger.error(`Could not find weapon with id ${weaponId}`, el);
+          renderBroken("BrokenCardMissingItem");
+          return;
+        }
         content = (
           <AttackCard
             msg={chatMessage}
@@ -80,6 +96,10 @@ export const installAbilityCardChatWrangler = () => {
             name={name}
           />
         );
+      } else if (!isAbilityItem(ability)) {
+        systemLogger.error(`Could not find ability with id ${abilityId}`, el);
+        renderBroken("BrokenCardMissingItem");
+        return;
       } else if (mode === constants.htmlDataModeMwTest) {
         // MW TEST
         const difficultyAttr = el.getAttribute(constants.htmlDataMwDifficulty);

--- a/src/startup/installAbilityCardChatWrangler.tsx
+++ b/src/startup/installAbilityCardChatWrangler.tsx
@@ -46,14 +46,6 @@ export const installAbilityCardChatWrangler = () => {
         );
       };
 
-      if (actorId === null) {
-        systemLogger.error(
-          `Missing or invalid '${constants.htmlDataActorId}' attribute.`,
-          el,
-        );
-        renderBroken("BrokenCardMissingActorId");
-        return;
-      }
       if (mode === null || !isAbilityCardMode(mode)) {
         systemLogger.error(
           "Ability test chat message found without a valid " +
@@ -67,13 +59,29 @@ export const installAbilityCardChatWrangler = () => {
 
       // foundry doesn't seem to have a canonical way to just grab an item
       // regardless of where it is (world, actor, token, compendium etc.)
-      const actor = tokenId
-        ? canvas?.tokens?.get(tokenId)?.actor
-        : game.actors?.get(actorId);
+      // try the token first, so that unlinked tokens get their own actor's
+      // data, but fall back to the world actor - either one can be a dead end
+      // (the token may be on a scene we're not looking at, or deleted
+      // entirely) so it's worth trying both before we give up.
+      const actor =
+        (tokenId ? canvas?.tokens?.get(tokenId)?.actor : undefined) ??
+        (actorId ? game.actors?.get(actorId) : undefined);
 
       if (actor === undefined || actor === null) {
-        systemLogger.error(`Could not find actor with id ${actorId}`, el);
-        renderBroken("BrokenCardMissingActor");
+        if (!actorId && !tokenId) {
+          systemLogger.error(
+            `Missing or invalid '${constants.htmlDataActorId}' and ` +
+              `'${constants.htmlDataTokenId}' attributes.`,
+            el,
+          );
+          renderBroken("BrokenCardMissingActorId");
+        } else {
+          systemLogger.error(
+            `Could not find actor with id ${actorId} or token with id ${tokenId}`,
+            el,
+          );
+          renderBroken("BrokenCardMissingActor");
+        }
         return;
       }
 


### PR DESCRIPTION
Fixes an error where the chat card for ability pushes would fail to re-render because of a broken actor id.

After the big conversion to datamodels, many sites in the code had to change from `this.parent.*` to `this.parent.parent.*`, because the call site is now in the data model, which is nested inside the actual document, where before the call site was directly on the document. Somehow, chat cards for pushes were missed out, so they were being given an actor id which was in fact the id of the ability item. This was missed in testing because it actually worked on the very first render in most cases; but users on a different scene, or anyone refreshing the page, would get a blank chat bubble and an error in the console.

Fixes #1380.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed push pool chat cards displaying incorrect actor or token information.
  - Prevented errors when ability cards reference missing or invalid actors, weapons, abilities, or roll types.
  - Replaced blank or unresolved cards with explanatory placeholders.
  - Added clearer messages for unknown abilities and other unavailable card details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->